### PR TITLE
Remove Arm64MsrReg, Arm64Vess, which were removed from Capstone in

### DIFF
--- a/hapstone.cabal
+++ b/hapstone.cabal
@@ -28,8 +28,10 @@ library
   build-depends:       base >= 4.7 && < 5
   default-language:    Haskell2010
   extra-libraries:     capstone
-  extra-lib-dirs:      /home/thewormkill/clones/forks/capstone/tests
-  include-dirs:        /home/thewormkill/clones/forks/capstone/include
+-- /home/thewormkill/clones/forks/capstone/tests
+  extra-lib-dirs:      /home/gregs/install/usr/local/lib
+-- /home/thewormkill/clones/forks/capstone/include
+  include-dirs:        /home/gregs/install/usr/local/include
   build-tools:         c2hs
 
 test-suite hapstone-test

--- a/test/Internal/Arm64/Default.hs
+++ b/test/Internal/Arm64/Default.hs
@@ -19,16 +19,18 @@ instance Arbitrary Arm64ConditionCode where
 
 instance Arbitrary Arm64Sysreg where
     arbitrary = elements [minBound..maxBound]
-instance Arbitrary Arm64MsrReg where
-    arbitrary = elements [minBound..maxBound]
+
+--instance Arbitrary Arm64MsrReg where
+--    arbitrary = elements [minBound..maxBound]
 
 instance Arbitrary Arm64Pstate where
     arbitrary = elements [minBound..maxBound]
 
 instance Arbitrary Arm64Vas where
     arbitrary = elements [minBound..maxBound]
-instance Arbitrary Arm64Vess where
-    arbitrary = elements [minBound..maxBound]
+
+-- instance Arbitrary Arm64Vess where
+--    arbitrary = elements [minBound..maxBound]
 
 instance Arbitrary Arm64BarrierOp where
     arbitrary = elements [minBound..maxBound]
@@ -71,7 +73,7 @@ instance Arbitrary CsArm64OpValue where
 
 instance Arbitrary CsArm64Op where
     arbitrary = CsArm64Op <$> arbitrary <*> arbitrary <*> arbitrary <*>
-        arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+        arbitrary <*> arbitrary <*> arbitrary
 
 instance Arbitrary CsArm64 where
     arbitrary = CsArm64 <$> arbitrary <*> arbitrary <*> arbitrary <*>

--- a/test/Internal/Arm64/StorableSpec.hs
+++ b/test/Internal/Arm64/StorableSpec.hs
@@ -44,7 +44,6 @@ getCsArm64Op = do
     ptr <- mallocArray (sizeOf csArm64Op) :: IO (Ptr Word8)
     poke (castPtr ptr) (0x01234567 :: Word32)
     poke (plusPtr ptr 4) (fromIntegral $ fromEnum Arm64Vas8b :: Int32)
-    poke (plusPtr ptr 8) (fromIntegral $ fromEnum Arm64VessB :: Int32)
     poke (plusPtr ptr 12) (fromIntegral $ fromEnum Arm64SftMsl :: Int32)
     poke (plusPtr ptr 16) (0x01234567 :: Word32)
     poke (plusPtr ptr 20) (fromIntegral $ fromEnum Arm64ExtUxtb :: Int32)
@@ -54,7 +53,7 @@ getCsArm64Op = do
     peek (castPtr ptr) <* free ptr
 
 csArm64Op :: CsArm64Op
-csArm64Op = CsArm64Op 0x01234567 Arm64Vas8b Arm64VessB
+csArm64Op = CsArm64Op 0x01234567 Arm64Vas8b 
     (Arm64SftMsl, 0x01234567) Arm64ExtUxtb (Imm 0x0123456789abcdef) 0x1
 
 csArm64OpSpec :: Spec


### PR DESCRIPTION
Remove Arm64MsrReg, Arm64Vess, which were removed from Capstone in
commit 9d292268, "arm64: sync with LLVM 7.0.1" 2019April10

Note that 'cabal test' fails; but it was failing before my commit also, in the same way. 
I don't know the correct way to fix that.

The point of this feature branch is to sync with the latest version of capstone (branch 'next') so that I can start adding support for capstone/riscv to hapstone.

(Note that I am a Haskell newbie and happy for advice/coaching -- thanks.)